### PR TITLE
41-docker - Allow us to obtain java heap-dumps in case of an OutOfMemoryError

### DIFF
--- a/docker-src/app/sources/start_app.sh
+++ b/docker-src/app/sources/start_app.sh
@@ -54,9 +54,14 @@ run_metasfresh()
  #               info: https://docs.oracle.com/cd/E26362_01/E40761/html/known-bugs-issues.html
  #                     https://stackoverflow.com/a/19379760
 
+# thx to 
+# https://blog.csanchez.org/2017/05/31/running-a-jvm-in-a-container-without-getting-killed/
+MEMORY_PARAMS="-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:MaxRAMFraction=1"
+
+
  cd /opt/metasfresh/ && java \
  -Dsun.misc.URLClassPath.disableJarChecking=true \
- -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap \
+ $MEMORY_PARAMS \
  -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/opt/metasfresh/heapdump \
  -DPropertyFile=/opt/metasfresh/metasfresh.properties \
  -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8788 \

--- a/docker-src/app/sources/start_app.sh
+++ b/docker-src/app/sources/start_app.sh
@@ -6,6 +6,7 @@ set -u
 DB_HOST=db
 APP_HOST=app
 
+
 set_properties()
 {
  local prop_file="$1"
@@ -55,7 +56,8 @@ run_metasfresh()
 
  cd /opt/metasfresh/ && java \
  -Dsun.misc.URLClassPath.disableJarChecking=true \
- -Xmx1024M -XX:MaxPermSize=512M -XX:+HeapDumpOnOutOfMemoryError \
+ -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap \
+ -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/opt/metasfresh/heapdump \
  -DPropertyFile=/opt/metasfresh/metasfresh.properties \
  -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8788 \
  -Dcom.sun.net.ssl.enableECC=false \

--- a/docker-src/docker-compose.yml
+++ b/docker-src/docker-compose.yml
@@ -18,6 +18,7 @@ app:
   restart: always
   volumes:
     - ./volumes/app/log:/opt/metasfresh/log:rw
+    - ./volumes/app/heapdump:/opt/metasfresh/heapdump:rw
     - /etc/localtime:/etc/localtime:ro
   environment:
     - METASFRESH_HOME=/opt/metasfresh
@@ -29,6 +30,7 @@ webapi:
   restart: always
   volumes:
     - ./volumes/webapi/log:/opt/metasfresh-webui-api/log:rw
+    - ./volumes/webapi/heapdump:/opt/metasfresh-webui-api/heapdump:rw
     - /etc/localtime:/etc/localtime:ro
 webui:
   build: webui

--- a/docker-src/docker-compose_v2.yml
+++ b/docker-src/docker-compose_v2.yml
@@ -22,6 +22,7 @@ services:
     restart: always
     volumes:
       - ./volumes/app/log:/opt/metasfresh/log:rw
+      - ./volumes/app/heapdump:/opt/metasfresh/heapdump:rw
       - /etc/localtime:/etc/localtime:ro
     environment:
       - METASFRESH_HOME=/opt/metasfresh
@@ -33,6 +34,7 @@ services:
     restart: always
     volumes:
       - ./volumes/webapi/log:/opt/metasfresh-webui-api/log:rw
+      - ./volumes/webapi/heapdump:/opt/metasfresh-webui-api/heapdump:rw
       - /etc/localtime:/etc/localtime:ro
 
   webui:

--- a/docker-src/webapi/sources/start_webapi.sh
+++ b/docker-src/webapi/sources/start_webapi.sh
@@ -35,10 +35,14 @@ wait_dbms()
  done
 }
 
+# thx to 
+# https://blog.csanchez.org/2017/05/31/running-a-jvm-in-a-container-without-getting-killed/
+MEMORY_PARAMS="-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:MaxRAMFraction=1"
+
 run_metasfresh()
 {
  cd /opt/metasfresh-webui-api/ && java -Dsun.misc.URLClassPath.disableJarChecking=true \
- -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap \
+ $MEMORY_PARAMS \
  -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/opt/metasfresh-webui-api/heapdump \
  -DPropertyFile=/opt/metasfresh-webui-api/metasfresh.properties \
  -Dcom.sun.management.jmxremote.port=1618 \

--- a/docker-src/webapi/sources/start_webapi.sh
+++ b/docker-src/webapi/sources/start_webapi.sh
@@ -1,9 +1,22 @@
 #!/bin/bash
 
 set -e
+#set -x
 
 DB_HOST=db
 APP_HOST=app
+
+echo_variable_values()
+{
+ echo "*************************************************************"
+ echo "Display the variable values we run with"
+ echo "*************************************************************"
+ echo "Note: all these variables can be set using the -e parameter."
+ echo ""
+ echo "DB_HOST=${DB_HOST}"
+ echo "APP_HOST=${APP_HOST}"
+ echo ""
+}
 
 set_properties()
 {
@@ -25,7 +38,8 @@ wait_dbms()
 run_metasfresh()
 {
  cd /opt/metasfresh-webui-api/ && java -Dsun.misc.URLClassPath.disableJarChecking=true \
- -Xmx1024M -XX:MaxPermSize=512M -XX:+HeapDumpOnOutOfMemoryError \
+ -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap \
+ -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/opt/metasfresh-webui-api/heapdump \
  -DPropertyFile=/opt/metasfresh-webui-api/metasfresh.properties \
  -Dcom.sun.management.jmxremote.port=1618 \
  -Dcom.sun.management.jmxremote.authenticate=false \
@@ -34,6 +48,7 @@ run_metasfresh()
  -jar metasfresh-webui-api.jar
 }
 
+echo_variable_values
 
 set_properties /opt/metasfresh-webui-api/metasfresh.properties
 set_properties /opt/metasfresh-webui-api/local_settings.properties


### PR DESCRIPTION
* add dedicated volumes for app and webapi
* bonus: derive memory settings from docker instead of setting them statically

https://github.com/metasfresh/metasfresh-docker/issues/41