### PR TITLE
4939-app - Configure c3p0's max db connection pool size

### DIFF
--- a/docker-src/app/Dockerfile
+++ b/docker-src/app/Dockerfile
@@ -1,5 +1,9 @@
 FROM ubuntu:16.04
 
+# to make sure that the cache is only used during one day, run docker build --build-arg CACHEBUST=$(date "+%Y-%m-%d")
+# that way we should get the latest updates since the release of our base image 
+# thx to https://github.com/moby/moby/issues/1996#issuecomment-185872769
+ARG CACHEBUST=1
 
 RUN apt update && apt -y full-upgrade
 RUN apt autoclean && apt update
@@ -15,6 +19,14 @@ RUN mkdir -p /opt/metasfresh
 RUN curl https://repo.metasfresh.com/content/repositories/mvn-release-releases/de/metas/dist/metasfresh-dist-dist/5.88.2-894+release/metasfresh-dist-dist-5.88.2-894+release-dist.tar.gz \
   | tar -xzC /opt/metasfresh/ 
 RUN mkdir -p /opt/metasfresh/heapdump
+
+# Explode the uber jar to make it easier to work with the docker image; 
+# e.g. with the exploded uber jar, we can later copy or overwrite config files into the docker image that change the applications behavior.
+# Note that the skript start_materialdispo_docker.sh is adapted to the exploded jar.
+# Note2 that we need unzip; jar doesn't work, thx to https://stackoverflow.com/a/39653862/1012103
+RUN cd /opt/metasfresh \
+ && (unzip -q /opt/metasfresh/metasfresh_server.jar || echo "Ignore exit code $? because spring boot's uber jar starts with a shell script") \
+ && rm /opt/metasfresh/metasfresh_server.jar
 
 COPY sources/configs/* /opt/metasfresh/
 COPY sources/configs/local_settings.properties /root/

--- a/docker-src/app/sources/configs/c3p0.properties
+++ b/docker-src/app/sources/configs/c3p0.properties
@@ -1,0 +1,8 @@
+# When the docker image is build, then this file overrides the default file which is present within the container.
+#
+# see https://www.mchange.com/projects/c3p0/index.html
+c3p0.initialPoolSize=5
+c3p0.minPoolSize=5
+c3p0.maxPoolSize=25
+
+c3p0.checkoutTimeout=0

--- a/docker-src/app/sources/start_app.sh
+++ b/docker-src/app/sources/start_app.sh
@@ -63,7 +63,7 @@ run_metasfresh()
  -DPropertyFile=/opt/metasfresh/metasfresh.properties \
  -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8788 \
  -Dcom.sun.net.ssl.enableECC=false \
- -jar metasfresh_server.jar
+ org.springframework.boot.loader.JarLauncher
 }
 
 run_install

--- a/docker-src/webapi/Dockerfile
+++ b/docker-src/webapi/Dockerfile
@@ -1,5 +1,9 @@
 FROM ubuntu:16.04
 
+# to make sure that the cache is only used during one day, run docker build --build-arg CACHEBUST=$(date "+%Y-%m-%d")
+# that way we should get the latest updates since the release of our base image 
+# thx to https://github.com/moby/moby/issues/1996#issuecomment-185872769
+ARG CACHEBUST=1
 
 RUN apt update && apt -y full-upgrade
 RUN apt autoclean && apt update
@@ -8,6 +12,7 @@ RUN apt -y install netcat \
     && apt -y install curl \
     && apt -y install openjdk-8-jdk-headless \
     && apt -y install postgresql-client-9.5 \
+    && apt -y install unzip \
     && apt -y autoremove \
     && apt -y autoclean
 
@@ -16,8 +21,15 @@ RUN mkdir -p /opt/metasfresh-webui-api/metasfresh-webui-api \
     && mkdir -p /opt/metasfresh-webui-api/log \
     && mkdir -p /opt/metasfresh-webui-api/heapdump
 RUN curl https://repo.metasfresh.com/content/repositories/mvn-release/de/metas/ui/web/metasfresh-webui-api/5.88.2-655+release/metasfresh-webui-api-5.88.2-655+release.jar \
-    --output /opt/metasfresh-webui-api/metasfresh-webui-api.jar \
-    && chmod 750 /opt/metasfresh-webui-api/metasfresh-webui-api.jar
+    --output /opt/metasfresh-webui-api/metasfresh-webui-api.jar
+
+# Explode the uber jar to make it easier to work with the docker image; 
+# e.g. with the exploded uber jar, we can later copy or overwrite config files into the docker image that change the applications behavior.
+# Note that the skript start_materialdispo_docker.sh is adapted to the exploded jar.
+# Note2 that we need unzip; jar doesn't work, thx to https://stackoverflow.com/a/39653862/1012103
+RUN cd /opt/metasfresh/metasfresh-webui-api \
+ && (unzip -q /opt/metasfresh/metasfresh-webui-api/metasfresh-webui-api || echo "Ignore exit code $? because spring boot's uber jar starts with a shell script") \
+ && rm /opt/metasfresh/metasfresh-webui-api/metasfresh-webui-api
 
 COPY sources/configs/* /opt/metasfresh-webui-api/
 COPY sources/start_webapi.sh /opt/metasfresh-webui-api/

--- a/docker-src/webapi/sources/configs/c3p0.properties
+++ b/docker-src/webapi/sources/configs/c3p0.properties
@@ -1,0 +1,8 @@
+# When the docker image is build, then this file overrides the default file which is present within the container.
+#
+# see https://www.mchange.com/projects/c3p0/index.htmlc3p0.initialPoolSize=10
+c3p0.initialPoolSize=10
+c3p0.minPoolSize=10
+c3p0.maxPoolSize=45
+
+c3p0.checkoutTimeout=0

--- a/docker-src/webapi/sources/start_webapi.sh
+++ b/docker-src/webapi/sources/start_webapi.sh
@@ -35,7 +35,7 @@ run_metasfresh()
  -Dcom.sun.management.jmxremote.authenticate=false \
  -Dcom.sun.management.jmxremote.ssl=false \
  -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8789 \
- -jar metasfresh-webui-api.jar
+ org.springframework.boot.loader.JarLauncher
 }
 
 


### PR DESCRIPTION
* explode uber-jar so we can simply add custom c3p0.properties files
* add support for not using cached base imaged for too long; see comment in Dockerfiles
https://github.com/metasfresh/metasfresh/issues/4939