### PR TITLE
Attempt to add cache control on index.html

### DIFF
--- a/webui/sources/configs/metasfresh_webui.conf
+++ b/webui/sources/configs/metasfresh_webui.conf
@@ -82,4 +82,13 @@
 		 RewriteRule ^ - [L]
   		 RewriteRule ^ /index.html
         </Directory>
+
+        <Files index.html>
+                FileETag None
+                Header unset ETag
+                Header set Cache-Control "max-age=0, no-cache, no-store, must-revalidate"
+                Header set Pragma "no-cache"
+                Header set Expires "Wed, 21 Oct 2015 07:28:00 GMT"
+        </Files>
+
 </VirtualHost>

--- a/webui/sources/configs/metasfresh_webui_ssl.conf
+++ b/webui/sources/configs/metasfresh_webui_ssl.conf
@@ -83,6 +83,14 @@
 		 RewriteRule ^ - [L]
   		 RewriteRule ^ /index.html
         </Directory>
+
+        <Files index.html>
+                FileETag None
+                Header unset ETag
+                Header set Cache-Control "max-age=0, no-cache, no-store, must-revalidate"
+                Header set Pragma "no-cache"
+                Header set Expires "Wed, 21 Oct 2015 07:28:00 GMT"
+        </Files>
 SSLCertificateFile /etc/apache2/certs/fullchain.pem
 SSLCertificateKeyFile /etc/apache2/certs/privkey.pem
 </VirtualHost>


### PR DESCRIPTION
Trying to disable the cache for one specific file (index.html) 

The bundle that is generated during build time on client machines is not refreshed due to caching (old bundle version is seen after deployment).

With this PR I am trying to force to be no cache for that file. 

I'm no expert on apache configs but this should do the trick. Pls check

Issue https://github.com/metasfresh/me03/issues/6583