### PR TITLE
#75 mitigate CVE-2021-44228 in elasticsearch container

### DIFF
--- a/search/Dockerfile
+++ b/search/Dockerfile
@@ -5,6 +5,9 @@ FROM docker.elastic.co/elasticsearch/elasticsearch:7.9.3
 # Also see https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html#docker-cli-run-dev-mode
 ENV discovery.type=single-node
 
+# mitigate CVE-2021-44228 log4j2 vulnerability - http://cve.mitre.org/cgi-bin/cvename.cgi?name=2021-44228
+ENV LOG4J_FORMAT_MSG_NO_LOOKUPS=true
+
 COPY sources/start-custom.sh /usr/local/bin/start-custom.sh
 RUN chmod +x /usr/local/bin/start-custom.sh
 


### PR DESCRIPTION
Deploying env-variable in Dockerfile of `search` container
```
ENV LOG4J_FORMAT_MSG_NO_LOOKUPS=true
```

as suggested here: 
- https://www.bsi.bund.de/SharedDocs/Cybersicherheitswarnungen/DE/2021/2021-549032-10F2.pdf?__blob=publicationFile&v=3
- https://www.docker.com/blog/apache-log4j-2-cve-2021-44228/

---

Tested by deploying to an instance and checking if the env-variable is set:
```
docker exec -it metasfresh-docker_search_1 /bin/bash

echo "$LOG4J_FORMAT_MSG_NO_LOOKUPS"
true #output
```